### PR TITLE
Remove unreachable code

### DIFF
--- a/pkg/cli/list/list.go
+++ b/pkg/cli/list/list.go
@@ -45,7 +45,6 @@ func NewCommand() (c *cobra.Command) {
 
 			if !configPresent && len(orgRepo) <= 0 {
 				log.Fatal("You must pass either a config file or repository as argument to continue.")
-				os.Exit(1)
 			}
 
 			ghClient := gitclient.Client(token, ctx)
@@ -58,10 +57,8 @@ func NewCommand() (c *cobra.Command) {
 
 				for _, v := range viper.GetStringSlice("repositories") {
 					pullRequests, _, err := ghClient.PullRequests.List(ctx, org, v, nil)
-
 					if err != nil {
 						log.Fatal(err)
-						os.Exit(1)
 					}
 
 					// Use variadic notation to append to array here...
@@ -89,7 +86,6 @@ func NewCommand() (c *cobra.Command) {
 				pullRequests, _, err := ghClient.PullRequests.List(ctx, org, repo, nil)
 				if err != nil {
 					log.Fatal(err)
-					os.Exit(1)
 				}
 
 				if len(pullRequests) == 0 {
@@ -174,7 +170,6 @@ func parseOrgRepo(repo string, configPresent bool) (org, repository string) {
 
 	if len(str) <= 1 {
 		log.Fatal("You must pass your repo name like so: organization/repository to continue.")
-		os.Exit(1)
 	}
 
 	org = str[0]

--- a/pkg/gitclient/client.go
+++ b/pkg/gitclient/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
@@ -32,7 +31,7 @@ func ApprovePullRequest(ghClient *github.Client, ctx context.Context, org, repo 
 	}
 	review, _, err := ghClient.PullRequests.CreateReview(ctx, org, repo, prId, reviewRequest)
 	if err != nil {
-		//TODO: Parse error to check if user tried to approve their own PR..
+		// TODO: Parse error to check if user tried to approve their own PR..
 		log.Fatalf("Could not approve pull request, did you try to approve your on pull request? - %v", err)
 	}
 
@@ -41,10 +40,8 @@ func ApprovePullRequest(ghClient *github.Client, ctx context.Context, org, repo 
 
 func MergePullRequest(ghClient *github.Client, ctx context.Context, org, repo string, prId int, mergeMethod string) {
 	result, _, err := ghClient.PullRequests.Merge(ctx, org, repo, prId, defaultCommitMsg(), &github.PullRequestOptions{MergeMethod: mergeMethod})
-
 	if err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 
 	fmt.Println(fmt.Sprintf("PR #%d: %v.", prId, *result.Message))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -23,7 +22,6 @@ func ReadConfigFile(path string) {
 	err := viper.ReadInConfig()
 	if err != nil {
 		log.Fatal(fmt.Errorf("Could not read config file: %s\n", err))
-		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
`os.Exit` after `log.Fatal` is never called, because `log.Fatal` calls `os.Exit(1)` internally.

> Fatal is equivalent to Print() followed by a call to os.Exit(1).

https://pkg.go.dev/log#Fatal