### PR TITLE
FEAT: Add support to skip un-mergable pull requests.

### DIFF
--- a/pkg/cli/gomerge/gomerge.go
+++ b/pkg/cli/gomerge/gomerge.go
@@ -18,6 +18,7 @@ func New() (c *cobra.Command) {
 	c.PersistentFlags().StringP("config", "c", "", "Pass an optional config file as an argument with list of repositories.")
 	c.PersistentFlags().BoolP("approve", "a", false, "Pass an optional approve flag as an argument which will only approve and not merge selected repos.")
 	c.PersistentFlags().StringP("merge-method", "m", "", "Pass an optional merge method for the pull request (merge [default], squash, rebase).")
+	c.PersistentFlags().BoolP("skip", "s", false, "Pass an optional flag to skip a pull request and continue if one or more are not mergable.")
 
 	c.MarkFlagRequired("token")
 
@@ -26,6 +27,7 @@ func New() (c *cobra.Command) {
 	viper.BindPFlag("config", c.PersistentFlags().Lookup("config"))
 	viper.BindPFlag("approve", c.PersistentFlags().Lookup("approve"))
 	viper.BindPFlag("merge-method", c.PersistentFlags().Lookup("merge-method"))
+	viper.BindPFlag("skip", c.PersistentFlags().Lookup("skip"))
 
 	c.AddCommand(list.NewCommand())
 	c.AddCommand(version.NewCommand())

--- a/pkg/cli/list/list.go
+++ b/pkg/cli/list/list.go
@@ -41,6 +41,7 @@ func NewCommand() (c *cobra.Command) {
 			approveOnly = viper.GetBool("approve")
 			mergeMethod := viper.GetString("merge-method")
 			flagToken := viper.GetString("token")
+			skip := viper.GetBool("skip")
 
 			if len(configFile) > 0 {
 				utils.ReadConfigFile(configFile)
@@ -85,9 +86,9 @@ func NewCommand() (c *cobra.Command) {
 					p := parsePrId(id)
 					prId, _ := strconv.Atoi(p[0])
 					if approveOnly {
-						gitclient.ApprovePullRequest(ghClient, ctx, org, repo, prId)
+						gitclient.ApprovePullRequest(ghClient, ctx, org, repo, prId, skip)
 					} else {
-						gitclient.MergePullRequest(ghClient, ctx, org, p[1], prId, mergeMethod)
+						gitclient.MergePullRequest(ghClient, ctx, org, p[1], prId, mergeMethod, skip)
 					}
 				}
 			} else {
@@ -108,9 +109,9 @@ func NewCommand() (c *cobra.Command) {
 					p := parsePrId(id)
 					prId, _ := strconv.Atoi(p[0])
 					if approveOnly {
-						gitclient.ApprovePullRequest(ghClient, ctx, org, repo, prId)
+						gitclient.ApprovePullRequest(ghClient, ctx, org, repo, prId, skip)
 					} else {
-						gitclient.MergePullRequest(ghClient, ctx, org, repo, prId, mergeMethod)
+						gitclient.MergePullRequest(ghClient, ctx, org, repo, prId, mergeMethod, skip)
 					}
 				}
 			}


### PR DESCRIPTION
### Description
Add support for skipping un-mergeable pull requests and allow a user to continue with a mass merge/approve as needed.

### Changes
Adds optional `skip` flag to skip pull requests which are not mergable.
