### PR TITLE
FEAT: Add support for windows binary and update goreleaser.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,15 @@ builds:
     - -X main.Version={{ .Version }}
     - -X main.Build={{ .Commit }}
     - -X main.BuildDate={{ .Date }}
+  goos:
+    - linux
+    - windows
+    - darwin
+  goarch:
+    - amd64
+    - arm
+    - arm64
+    - 386
 archives:
 -
   id: gomerge
@@ -24,10 +33,28 @@ snapshot:
   name_template: "{{ .Tag }}"
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
     - '^docs:'
     - '^test:'
+    - '^typo|TYPO'
+    - typo
+    - Merge pull request
+    - Merge remote-tracking branch
+    - Merge branch
+  groups:
+    - title: 'New Features'
+      regexp: "^.*FEAT|WATCHER|CLI|EVENT|UTILS|CMD[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Fixes'
+      order: 10
+      regexp: "^.*FIX|CHORE|BUGFIX|EXAMPLES|BUG[(\\w)]*:+.*$"
+    - title: 'Workflow Updates'
+      regexp: "^.*ACTIONS|ACTION[(\\w)]*:+.*$"
+      order: 20
+    - title: 'Other things'
+      order: 999
 nfpms:
 -
   replacements:


### PR DESCRIPTION
This PR adds support for windows binaries for `gomerge`.