### PR TITLE
Display commit status in UI and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
+debug.log
 bin/*
 dist/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Available Commands:
 Flags:
   -a, --approve                      Pass an optional approve flag as an argument which will only approve and not merge selected repos.
       --close                        Pass an optional argument to close a pull request.
-      --commit-msg string            Add a custom message when approving a pull request.
   -c, --config string                Pass an optional config file as an argument with list of repositories.
   -d, --delay int                    Set the value of delay, which will determine how long to wait between mergeing pull requests. Default is (6) seconds. (default 6)
   -e, --enterprise-base-url string   For Github Enterprise users, you can pass your enterprise base. Format: http(s)://[hostname]/

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
-	github.com/google/go-github/v45 v45.2.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.9.0
@@ -16,7 +16,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
@@ -30,14 +29,12 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 // indirect
 	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
-	golang.org/x/crypto v0.13.0 // indirect
 	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/term v0.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 // indirect
+	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,10 +109,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=
-github.com/google/go-github/v45 v45.2.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
-github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
-github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -230,8 +226,6 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
-golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,10 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 h1:cYCy18SHPKRkvclm+pWm1Lk4YrREb4IOIb/YdFO0p2M=
+github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7/go.mod h1:zqMwyHmnN/eDOZOdiTohqIUKUrTFX62PNlu7IJdu0q8=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=

--- a/pkg/cli/gomerge/gomerge.go
+++ b/pkg/cli/gomerge/gomerge.go
@@ -14,6 +14,7 @@ func New() (c *cobra.Command) {
 	}
 
 	c.PersistentFlags().StringP("repo", "r", "", "Pass name of repository as argument (organization/repo).")
+	c.PersistentFlags().StringArrayP("label", "l", []string{}, "Pass an optional list of labels to filter pull requests.")
 	c.PersistentFlags().StringP("token", "t", "", "Pass your github personal access token (PAT).")
 	c.PersistentFlags().StringP("config", "c", "", "Pass an optional config file as an argument with list of repositories.")
 	c.PersistentFlags().BoolP("approve", "a", false, "Pass an optional approve flag as an argument which will only approve and not merge selected repos.")
@@ -26,6 +27,7 @@ func New() (c *cobra.Command) {
 	c.MarkFlagRequired("token")
 
 	viper.BindPFlag("repo", c.PersistentFlags().Lookup("repo"))
+	viper.BindPFlag("label", c.PersistentFlags().Lookup("label"))
 	viper.BindPFlag("token", c.PersistentFlags().Lookup("token"))
 	viper.BindPFlag("config", c.PersistentFlags().Lookup("config"))
 	viper.BindPFlag("approve", c.PersistentFlags().Lookup("approve"))

--- a/pkg/cli/gomerge/gomerge.go
+++ b/pkg/cli/gomerge/gomerge.go
@@ -1,10 +1,11 @@
 package gomerge
 
 import (
-	"github.com/cian911/go-merge/pkg/cli/list"
-	"github.com/cian911/go-merge/pkg/cli/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/cian911/go-merge/pkg/cli/list"
+	"github.com/cian911/go-merge/pkg/cli/version"
 )
 
 func New() (c *cobra.Command) {
@@ -13,16 +14,25 @@ func New() (c *cobra.Command) {
 		Short: "Gomerge makes it simple to merge an open pull request from your terminal.",
 	}
 
-	c.PersistentFlags().StringP("repo", "r", "", "Pass name of repository as argument (organization/repo).")
-	c.PersistentFlags().StringArrayP("label", "l", []string{}, "Pass an optional list of labels to filter pull requests.")
+	c.PersistentFlags().
+		StringP("repo", "r", "", "Pass name of repository as argument (organization/repo).")
+	c.PersistentFlags().
+		StringArrayP("label", "l", []string{}, "Pass an optional list of labels to filter pull requests. (label1,label2,label3)")
 	c.PersistentFlags().StringP("token", "t", "", "Pass your github personal access token (PAT).")
-	c.PersistentFlags().StringP("config", "c", "", "Pass an optional config file as an argument with list of repositories.")
-	c.PersistentFlags().BoolP("approve", "a", false, "Pass an optional approve flag as an argument which will only approve and not merge selected repos.")
-	c.PersistentFlags().StringP("merge-method", "m", "", "Pass an optional merge method for the pull request (merge [default], squash, rebase).")
-	c.PersistentFlags().BoolP("skip", "s", false, "Pass an optional flag to skip a pull request and continue if one or more are not mergable.")
-	c.PersistentFlags().BoolP("close", "", false, "Pass an optional argument to close a pull request.")
-	c.PersistentFlags().IntP("delay", "d", 6, "Set the value of delay, which will determine how long to wait between mergeing pull requests. Default is (6) seconds.")
-	c.PersistentFlags().StringP("enterprise-base-url", "e", "", "For Github Enterprise users, you can pass your enterprise base. Format: http(s)://[hostname]/")
+	c.PersistentFlags().
+		StringP("config", "c", "", "Pass an optional config file as an argument with list of repositories.")
+	c.PersistentFlags().
+		BoolP("approve", "a", false, "Pass an optional approve flag as an argument which will only approve and not merge selected repos.")
+	c.PersistentFlags().
+		StringP("merge-method", "m", "", "Pass an optional merge method for the pull request (merge [default], squash, rebase).")
+	c.PersistentFlags().
+		BoolP("skip", "s", false, "Pass an optional flag to skip a pull request and continue if one or more are not mergable.")
+	c.PersistentFlags().
+		BoolP("close", "", false, "Pass an optional argument to close a pull request.")
+	c.PersistentFlags().
+		IntP("delay", "d", 6, "Set the value of delay, which will determine how long to wait between mergeing pull requests. Default is (6) seconds.")
+	c.PersistentFlags().
+		StringP("enterprise-base-url", "e", "", "For Github Enterprise users, you can pass your enterprise base. Format: http(s)://[hostname]/")
 
 	c.MarkFlagRequired("token")
 

--- a/pkg/cli/gomerge/gomerge.go
+++ b/pkg/cli/gomerge/gomerge.go
@@ -22,7 +22,6 @@ func New() (c *cobra.Command) {
 	c.PersistentFlags().BoolP("close", "", false, "Pass an optional argument to close a pull request.")
 	c.PersistentFlags().IntP("delay", "d", 6, "Set the value of delay, which will determine how long to wait between mergeing pull requests. Default is (6) seconds.")
 	c.PersistentFlags().StringP("enterprise-base-url", "e", "", "For Github Enterprise users, you can pass your enterprise base. Format: http(s)://[hostname]/")
-  c.PersistentFlags().StringP("commit-msg", "", "", "Add a custom message when approving a pull request.")
 
 	c.MarkFlagRequired("token")
 
@@ -35,7 +34,6 @@ func New() (c *cobra.Command) {
 	viper.BindPFlag("delay", c.PersistentFlags().Lookup("delay"))
 	viper.BindPFlag("close", c.PersistentFlags().Lookup("close"))
 	viper.BindPFlag("enterprise-base-url", c.PersistentFlags().Lookup("enterprise-base-url"))
-  viper.BindPFlag("commit-msg", c.PersistentFlags().Lookup("commit-msg"))
 
 	c.AddCommand(list.NewCommand())
 	c.AddCommand(version.NewCommand())

--- a/pkg/cli/list/list.go
+++ b/pkg/cli/list/list.go
@@ -207,7 +207,7 @@ func statusIcon(state string) (icon string) {
 func formatTable(pr *gitclient.PullRequest) (data []string) {
 	data = []string{
 		fmt.Sprintf("#%d", pr.Number),
-		fmt.Sprintf("%s %s", pr.State, statusIcon(pr.CheckConclusion)),
+		fmt.Sprintf("%s %s", pr.State, statusIcon(pr.StatusRollup)),
 		pr.Title,
 		fmt.Sprintf("%s/%s", pr.RepositoryOwner, pr.RepositoryName),
 		printer.FormatTime(&pr.CreatedAt),

--- a/pkg/cli/list/list.go
+++ b/pkg/cli/list/list.go
@@ -127,16 +127,19 @@ func NewCommand() (c *cobra.Command) {
 			}
 
 			selectedIds := promptAndFormat(pullRequestsArray, table)
-			for _, id := range selectedIds {
+			for i, id := range selectedIds {
 
 				if approveOnly {
 					gitclient.ApprovePullRequest(ghClient, ctx, id, skip)
 				} else if closePr {
 					gitclient.ClosePullRequest(ghClient, ctx, id, skip)
 				} else {
-					gitclient.MergePullRequest(ghClient, ctx, id, &mergeMethod, skip)
 					// delay between merges to allow other active PRs to get synced
-					time.Sleep(time.Duration(delay) * time.Second)
+					if i > 0 {
+						time.Sleep(time.Duration(delay) * time.Second)
+					}
+					gitclient.MergePullRequest(ghClient, ctx, id, &mergeMethod, skip)
+
 				}
 			}
 		},

--- a/pkg/cli/list/list.go
+++ b/pkg/cli/list/list.go
@@ -86,7 +86,6 @@ func NewCommand() (c *cobra.Command) {
 
 			pullRequestsArray := []*gitclient.PullRequest{}
 			table := initTable()
-			ctx = commitMsg(ctx, viper.GetString("commit-msg"))
 
 			var org string
 			var repositories []string = nil

--- a/pkg/cli/list/list_test.go
+++ b/pkg/cli/list/list_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cian911/go-merge/pkg/gitclient"
 	"github.com/cian911/go-merge/pkg/printer"
-	"github.com/google/go-github/v45/github"
 	"github.com/olekukonko/tablewriter"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,47 +37,30 @@ func TestInitTable(t *testing.T) {
 }
 
 func TestFormatTable(t *testing.T) {
-	var (
-		org  = "Cian911"
-		repo = "syncwave"
-	)
-
 	t.Run("It returns a string array", func(t *testing.T) {
 		number := 1
 		state := "#open"
 		title := "My Pr"
 		createdAt := time.Now()
 
-		pr := &github.PullRequest{
-			Number:    &number,
-			State:     &state,
-			Title:     &title,
-			CreatedAt: &createdAt,
+		pr := &gitclient.PullRequest{
+			RepositoryOwner: "Cian911",
+			RepositoryName:  "syncwave",
+			Number:          number,
+			State:           state,
+			Title:           title,
+			CheckConclusion: "SUCCESS",
+			CreatedAt:       createdAt,
 		}
 
-		got := formatTable(pr, org, repo)
+		got := formatTable(pr)
 		want := []string{
 			"#1",
-			"#open",
+			"#open ✅",
 			"My Pr",
 			"Cian911/syncwave",
-			printer.FormatTime(pr.CreatedAt),
+			printer.FormatTime(&pr.CreatedAt),
 		}
-
-		assert.Equal(t, got, want)
-	})
-
-	t.Run("It returns an empty string array when attrs are not present in pr struct", func(t *testing.T) {
-		state := "#open"
-		title := "My Pr"
-
-		pr := &github.PullRequest{
-			State: &state,
-			Title: &title,
-		}
-
-		got := formatTable(pr, org, repo)
-		want := []string(nil)
 
 		assert.Equal(t, got, want)
 	})

--- a/pkg/cli/list/list_test.go
+++ b/pkg/cli/list/list_test.go
@@ -5,27 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cian911/go-merge/pkg/gitclient"
-	"github.com/cian911/go-merge/pkg/printer"
 	"github.com/olekukonko/tablewriter"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cian911/go-merge/pkg/gitclient"
+	"github.com/cian911/go-merge/pkg/printer"
 )
-
-func TestParseOrgRepo(t *testing.T) {
-	t.Run("It returns a valid tuple when no config is present", func(t *testing.T) {
-		repo := "Cian911/syncwave"
-		configPresent := false
-
-		want1 := "Cian911"
-		want2 := "syncwave"
-
-		got1, got2 := parseOrgRepo(repo, configPresent)
-
-		if got1 != want1 || got2 != want2 {
-			t.Errorf("got1: %s, got2: %s, want1: %s, want2: %s", got1, got2, want1, want2)
-		}
-	})
-}
 
 func TestInitTable(t *testing.T) {
 	t.Run("It returns a tablewriter pointer", func(t *testing.T) {
@@ -53,10 +38,10 @@ func TestFormatTable(t *testing.T) {
 			CreatedAt:       createdAt,
 		}
 
-		got := formatTable(pr)
+		got, _ := formatTable(pr)
 		want := []string{
 			"#1",
-			"#open ✅",
+			"#open ",
 			"My Pr",
 			"Cian911/syncwave",
 			printer.FormatTime(&pr.CreatedAt),
@@ -73,62 +58,83 @@ func TestListGetToken(t *testing.T) {
 		envVar = "env@token"
 	)
 
-	t.Run("When a given token is set by flag, it should return token as the flag value", func(t *testing.T) {
-		got, err := getToken(flag, "")
-		want := flag
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-	})
+	t.Run(
+		"When a given token is set by flag, it should return token as the flag value",
+		func(t *testing.T) {
+			got, err := getToken(flag, "")
+			want := flag
+			assert.Nil(t, err)
+			assert.Equal(t, want, got)
+		},
+	)
 
-	t.Run("When a given token is set by config, it should return token as defined on the configuration file", func(t *testing.T) {
-		got, err := getToken("", config)
-		want := config
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-	})
+	t.Run(
+		"When a given token is set by config, it should return token as defined on the configuration file",
+		func(t *testing.T) {
+			got, err := getToken("", config)
+			want := config
+			assert.Nil(t, err)
+			assert.Equal(t, want, got)
+		},
+	)
 
-	t.Run("When a given token is set by environment variable, it should return token as defined on the environment", func(t *testing.T) {
-		os.Setenv(TokenEnvVar, envVar)
-		got, err := getToken("", "")
-		want := envVar
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-		os.Unsetenv(TokenEnvVar)
-	})
+	t.Run(
+		"When a given token is set by environment variable, it should return token as defined on the environment",
+		func(t *testing.T) {
+			os.Setenv(TokenEnvVar, envVar)
+			got, err := getToken("", "")
+			want := envVar
+			assert.Nil(t, err)
+			assert.Equal(t, want, got)
+			os.Unsetenv(TokenEnvVar)
+		},
+	)
 
-	t.Run("When a given token is set on flag and config file, it should return the value set on flag", func(t *testing.T) {
-		got, err := getToken(flag, config)
-		want := flag
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-	})
+	t.Run(
+		"When a given token is set on flag and config file, it should return the value set on flag",
+		func(t *testing.T) {
+			got, err := getToken(flag, config)
+			want := flag
+			assert.Nil(t, err)
+			assert.Equal(t, want, got)
+		},
+	)
 
-	t.Run("When a given token is set on flag and environment, it should return the value set on the flag", func(t *testing.T) {
-		os.Setenv(TokenEnvVar, envVar)
-		got, err := getToken(flag, "")
-		want := flag
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-		os.Unsetenv(TokenEnvVar)
-	})
+	t.Run(
+		"When a given token is set on flag and environment, it should return the value set on the flag",
+		func(t *testing.T) {
+			os.Setenv(TokenEnvVar, envVar)
+			got, err := getToken(flag, "")
+			want := flag
+			assert.Nil(t, err)
+			assert.Equal(t, want, got)
+			os.Unsetenv(TokenEnvVar)
+		},
+	)
 
-	t.Run("When a given token is set on config file and environment, it should return the value set on the config file", func(t *testing.T) {
-		os.Setenv(TokenEnvVar, envVar)
-		got, err := getToken("", config)
-		want := config
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-		os.Unsetenv(TokenEnvVar)
-	})
+	t.Run(
+		"When a given token is set on config file and environment, it should return the value set on the config file",
+		func(t *testing.T) {
+			os.Setenv(TokenEnvVar, envVar)
+			got, err := getToken("", config)
+			want := config
+			assert.Nil(t, err)
+			assert.Equal(t, want, got)
+			os.Unsetenv(TokenEnvVar)
+		},
+	)
 
-	t.Run("When a given token is set on flag, config file, and environment, it should return the value set on flag", func(t *testing.T) {
-		os.Setenv(TokenEnvVar, envVar)
-		got, err := getToken(flag, config)
-		want := flag
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-		os.Unsetenv(TokenEnvVar)
-	})
+	t.Run(
+		"When a given token is set on flag, config file, and environment, it should return the value set on flag",
+		func(t *testing.T) {
+			os.Setenv(TokenEnvVar, envVar)
+			got, err := getToken(flag, config)
+			want := flag
+			assert.Nil(t, err)
+			assert.Equal(t, want, got)
+			os.Unsetenv(TokenEnvVar)
+		},
+	)
 
 	t.Run("When no token is passed should return error", func(t *testing.T) {
 		got, err := getToken("", "")

--- a/pkg/cli/list/list_test.go
+++ b/pkg/cli/list/list_test.go
@@ -49,7 +49,7 @@ func TestFormatTable(t *testing.T) {
 			Number:          number,
 			State:           state,
 			Title:           title,
-			CheckConclusion: "SUCCESS",
+			StatusRollup:    "SUCCESS",
 			CreatedAt:       createdAt,
 		}
 

--- a/pkg/gitclient/client.go
+++ b/pkg/gitclient/client.go
@@ -194,14 +194,12 @@ func ApprovePullRequest(ghClient *githubv4.Client, ctx context.Context, prId git
 		fmt.Printf("PR %v: %v\n", prId, review.State)
 	}
 }
+
 func MergePullRequest(ghClient *githubv4.Client, ctx context.Context, prId githubv4.ID, mergeMethod *githubv4.PullRequestMergeMethod, skip bool) {
 
-	commitMessage := githubv4.String(defaultCommitMsg())
-
 	input := githubv4.MergePullRequestInput{
-		PullRequestID:  prId,
-		CommitHeadline: &commitMessage,
-		MergeMethod:    mergeMethod,
+		PullRequestID: prId,
+		MergeMethod:   mergeMethod,
 	}
 
 	var m struct {
@@ -253,10 +251,6 @@ func ClosePullRequest(ghClient *githubv4.Client, ctx context.Context, prId githu
 
 	fmt.Printf("PR %s#%d closed: %v\n", pr.Repository.NameWithOwner, pr.Number, pr.Closed)
 
-}
-
-func defaultCommitMsg() string {
-	return "Merged by gomerge CLI."
 }
 
 func DefaultApproveMsg() string {

--- a/pkg/gitclient/client.go
+++ b/pkg/gitclient/client.go
@@ -4,11 +4,60 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/google/go-github/v45/github"
+	"github.com/shurcooL/githubv4"
+
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 )
+
+type PullRequest struct {
+	RepositoryOwner string
+	RepositoryName  string
+	Number          int
+	Title           string
+	State           string
+	CreatedAt       time.Time
+	ID              githubv4.ID
+	CheckConclusion string
+}
+
+type Commits struct {
+	Nodes []struct {
+		Commit struct {
+			CheckSuites struct {
+				Nodes []struct {
+					App struct {
+						Name githubv4.String
+					}
+					Status     githubv4.String
+					Conclusion githubv4.String
+				}
+			} `graphql:"checkSuites(first: $maxCheckSuites)"`
+		}
+	}
+}
+
+type Repository struct {
+	NameWithOwner githubv4.String
+	Owner         struct {
+		Login githubv4.String
+	}
+	Name         githubv4.String
+	PullRequests struct {
+		Nodes []struct {
+			Number    githubv4.Int
+			Title     githubv4.String
+			State     githubv4.String
+			Url       githubv4.URI
+			CreatedAt githubv4.DateTime
+			ID        githubv4.ID
+			Commits   Commits `graphql:"commits(last:1)"`
+		}
+	} `graphql:"pullRequests(states: [OPEN], first: $maxPullRequests, orderBy: {field: CREATED_AT, direction: DESC})"`
+}
 
 func Client(githubToken string, ctx context.Context, isEnterprise bool) (client *github.Client) {
 	tokenSource := oauth2.StaticTokenSource(
@@ -35,46 +84,212 @@ func Client(githubToken string, ctx context.Context, isEnterprise bool) (client 
 	return
 }
 
-func ApprovePullRequest(ghClient *github.Client, ctx context.Context, org, repo string, prId int, skip bool) {
-	// Create review
-  commitMsg := ctx.Value("message").(string)
-	e := "APPROVE"
-	reviewRequest := &github.PullRequestReviewRequest{
-		Body:  &commitMsg,
-		Event: &e,
-	}
-	review, _, err := ghClient.PullRequests.CreateReview(ctx, org, repo, prId, reviewRequest)
-	if err != nil && !skip {
-		log.Fatalf("Could not approve pull request, did you try to approve your on pull request? - %v", err)
-	} 
+func ClientV4(githubToken string, ctx context.Context, isEnterprise bool) (client *githubv4.Client) {
+	tokenSource := oauth2.StaticTokenSource(
+		&oauth2.Token{
+			AccessToken: githubToken,
+		},
+	)
 
-  if err != nil && skip {
-    fmt.Printf("Could not approve pull request, skipping.")
-  } else {
-    fmt.Printf("PR #%d: %v\n", prId, *review.State)
-  }
-}
+	httpClient := oauth2.NewClient(context.Background(), tokenSource)
 
-func MergePullRequest(ghClient *github.Client, ctx context.Context, org, repo string, prId int, mergeMethod string, skip bool) {
-	result, _, err := ghClient.PullRequests.Merge(ctx, org, repo, prId, defaultCommitMsg(), &github.PullRequestOptions{MergeMethod: mergeMethod})
-	if err != nil {
-		log.Printf("Could not merge PR #%d, skipping: %v\n", prId, err)
-
-		return
-	}
-
-	fmt.Sprintf("PR #%d: %v.\n", prId, *result.Message)
-}
-
-func ClosePullRequest(ghClient *github.Client, ctx context.Context, org, repo string, prId int, prRef *github.PullRequest) {
-	// Set Closed state for PR
-	*prRef.State = "closed"
-	result, _, err := ghClient.PullRequests.Edit(ctx, org, repo, prId, prRef)
-	if err != nil {
-		log.Printf("Could not close PR #%d - %v", prId, err)
+	if isEnterprise {
+		baseUrl := viper.GetString("enterprise-base-url")
+		client = githubv4.NewEnterpriseClient(baseUrl, httpClient)
 	} else {
-		fmt.Sprintf("PR #%d: %v.\n", prId, *result.State)
+		client = githubv4.NewClient(httpClient)
+
 	}
+
+	return
+}
+
+func ReduceCheckConclusions(commits *Commits) string {
+	// Check if there are no commits
+	if len(commits.Nodes) == 0 {
+		return ""
+	}
+
+	commit := commits.Nodes[0]
+
+	status := ""
+	for _, checkSuite := range commit.Commit.CheckSuites.Nodes {
+		if checkSuite.Status == "QUEUED" {
+			continue
+		}
+		if checkSuite.Status == "IN_PROGRESS" || checkSuite.Status == "PENDING" || checkSuite.Status == "WAITING" {
+			status = "IN_PROGRESS"
+			break
+		}
+		if checkSuite.Conclusion == "FAILURE" || checkSuite.Status == "CANCELLED" || checkSuite.Status == "ACTION_REQUIRED" {
+			status = "FAILURE"
+			break
+		}
+		if checkSuite.Conclusion == "SUCCESS" {
+			status = "SUCCESS"
+		}
+
+	}
+
+	return status
+}
+
+func GetPullRequests(client *githubv4.Client, ctx context.Context, owner string, repo string) ([]*PullRequest, error) {
+	vars := map[string]interface{}{
+		"maxPullRequests": githubv4.Int(10),
+		"maxCheckSuites":  githubv4.Int(10),
+		"owner":           githubv4.String(owner),
+	}
+
+	repos := []Repository{}
+
+	if repo == "" {
+		var q struct {
+			RepositoryOwner struct {
+				Repositories struct {
+					Nodes []Repository
+				} `graphql:"repositories(first: $maxRepositories, isFork: false, isArchived: false, isLocked: false, orderBy: {field: UPDATED_AT, direction: DESC})"`
+			} `graphql:"repositoryOwner(login: $owner)"`
+		}
+		vars["maxRepositories"] = githubv4.Int(100)
+		err := client.Query(ctx, &q, vars)
+		if err != nil {
+			return nil, err
+		}
+		repos = append(repos, q.RepositoryOwner.Repositories.Nodes...)
+		for _, repo := range repos {
+			fmt.Printf("Found repo: %v\n", repo.NameWithOwner)
+		}
+	} else {
+		var q struct {
+			Repository Repository `graphql:"repository(owner: $owner, name: $name)"`
+		}
+		vars["name"] = githubv4.String(repo)
+		err := client.Query(ctx, &q, vars)
+		if err != nil {
+			return nil, err
+		}
+		repos = append(repos, q.Repository)
+	}
+
+	pullRequests := []*PullRequest{}
+	for _, repo := range repos {
+		for _, pr := range repo.PullRequests.Nodes {
+			pullRequest := &PullRequest{
+				RepositoryOwner: string(repo.Owner.Login),
+				RepositoryName:  string(repo.Name),
+				Number:          int(pr.Number),
+				Title:           string(pr.Title),
+				State:           string(pr.State),
+				CreatedAt:       pr.CreatedAt.Time,
+				ID:              pr.ID,
+				CheckConclusion: ReduceCheckConclusions(&pr.Commits),
+			}
+
+			pullRequests = append(pullRequests, pullRequest)
+		}
+	}
+
+	return pullRequests, nil
+}
+
+func ApprovePullRequest(ghClient *githubv4.Client, ctx context.Context, prId githubv4.ID, skip bool) {
+
+	commitMessage := ctx.Value("message").(githubv4.String)
+	event := githubv4.PullRequestReviewEventApprove
+
+	input := githubv4.AddPullRequestReviewInput{
+		PullRequestID: prId,
+		Body:          &commitMessage,
+		Event:         &event,
+	}
+
+	var m struct {
+		AddPullRequestReview struct {
+			PullRequest struct {
+				Number     githubv4.Int
+				Repository struct {
+					NameWithOwner githubv4.String
+				}
+			}
+			PullRequestReview struct {
+				State githubv4.String
+			}
+		} `graphql:"addPullRequestReview(input: $input)"`
+	}
+
+	err := ghClient.Mutate(ctx, &m, input, nil)
+	if err != nil && !skip {
+		log.Printf("Could not approve pull request %v, did you try to approve your on pull request? - %v\n", prId, err)
+	}
+
+	review := m.AddPullRequestReview.PullRequestReview
+
+	if err != nil && skip {
+		fmt.Printf("Could not approve pull request, skipping.")
+	} else {
+		fmt.Printf("PR %v: %v\n", prId, review.State)
+	}
+}
+func MergePullRequest(ghClient *githubv4.Client, ctx context.Context, prId githubv4.ID, mergeMethod *githubv4.PullRequestMergeMethod, skip bool) {
+
+	commitMessage := githubv4.String(defaultCommitMsg())
+
+	input := githubv4.MergePullRequestInput{
+		PullRequestID:  prId,
+		CommitHeadline: &commitMessage,
+		MergeMethod:    mergeMethod,
+	}
+
+	var m struct {
+		MergePullRequest struct {
+			PullRequest struct {
+				Merged     bool
+				Number     githubv4.Int
+				Repository struct {
+					NameWithOwner githubv4.String
+				}
+			}
+		} `graphql:"mergePullRequest(input: $input)"`
+	}
+
+	err := ghClient.Mutate(ctx, &m, input, nil)
+	if err != nil {
+		log.Printf("Could not merge PR %s, skipping: %v\n", prId, err)
+	}
+
+	pr := m.MergePullRequest.PullRequest
+
+	fmt.Printf("PR %s#%d merged: %v\n", pr.Repository.NameWithOwner, pr.Number, pr.Merged)
+}
+
+func ClosePullRequest(ghClient *githubv4.Client, ctx context.Context, prId githubv4.ID, skip bool) {
+
+	input := githubv4.ClosePullRequestInput{
+		PullRequestID: prId,
+	}
+
+	var m struct {
+		ClosePullRequest struct {
+			PullRequest struct {
+				Closed     bool
+				Number     githubv4.Int
+				Repository struct {
+					NameWithOwner githubv4.String
+				}
+			}
+		} `graphql:"closePullRequest(input: $input)"`
+	}
+
+	err := ghClient.Mutate(ctx, &m, input, nil)
+	if err != nil {
+		log.Printf("Could not close PR %s, skipping: %v\n", prId, err)
+	}
+
+	pr := m.ClosePullRequest.PullRequest
+
+	fmt.Printf("PR %s#%d closed: %v\n", pr.Repository.NameWithOwner, pr.Number, pr.Closed)
+
 }
 
 func defaultCommitMsg() string {

--- a/pkg/gitclient/client.go
+++ b/pkg/gitclient/client.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/google/go-github/v45/github"
 	"github.com/shurcooL/githubv4"
 
 	"github.com/spf13/viper"
@@ -23,31 +22,6 @@ type PullRequest struct {
 	ID              githubv4.ID
 	StatusRollup    string
 	NeedsReview     bool
-}
-
-func Client(githubToken string, ctx context.Context, isEnterprise bool) (client *github.Client) {
-	tokenSource := oauth2.StaticTokenSource(
-		&oauth2.Token{
-			AccessToken: githubToken,
-		},
-	)
-
-	tokenContext := oauth2.NewClient(ctx, tokenSource)
-
-	if isEnterprise {
-		baseUrl := viper.GetString("enterprise-base-url")
-		c, err := github.NewEnterpriseClient(baseUrl, baseUrl, tokenContext)
-
-		if err != nil {
-			log.Fatalf("Could not auth enterprise client: %v", err)
-		}
-
-		client = c
-	} else {
-		client = github.NewClient(tokenContext)
-	}
-
-	return
 }
 
 func ClientV4(githubToken string, ctx context.Context, isEnterprise bool) (client *githubv4.Client) {

--- a/pkg/gitclient/client_test.go
+++ b/pkg/gitclient/client_test.go
@@ -4,17 +4,6 @@ import (
 	"testing"
 )
 
-func TestDefaultCommitMsg(t *testing.T) {
-	t.Run("It returns a default commit message", func(t *testing.T) {
-		got := defaultCommitMsg()
-		want := "Merged by gomerge CLI."
-
-		if got != want {
-			t.Errorf("got %s, want %s", got, want)
-		}
-	})
-}
-
 func TestDefaultApproveMsg(t *testing.T) {
 	t.Run("It returns a default approve message.", func(t *testing.T) {
 		got := DefaultApproveMsg()

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -24,16 +24,33 @@ func HeaderStyle(t *tablewriter.Table) *tablewriter.Table {
 
 func SuccessStyle(t *tablewriter.Table, data []string) *tablewriter.Table {
 	t.Rich(data, []tablewriter.Colors{
-		tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiCyanColor},
-		tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiGreenColor},
-		tablewriter.Colors{tablewriter.Bold},
-		tablewriter.Colors{tablewriter.Bold},
-		tablewriter.Colors{tablewriter.Bold},
+		{tablewriter.Bold, tablewriter.FgHiCyanColor},
+		{tablewriter.Bold, tablewriter.FgHiGreenColor},
+		{tablewriter.Bold},
+		{tablewriter.Bold},
+		{tablewriter.Bold},
 	})
 	return t
 }
 
 func ErrorStyle(t *tablewriter.Table, data []string) *tablewriter.Table {
-	t.Rich(data, []tablewriter.Colors{tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiRedColor}, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiRedColor}})
+	t.Rich(
+		data,
+		[]tablewriter.Colors{
+			{tablewriter.Bold, tablewriter.FgHiCyanColor},
+			{tablewriter.Bold, tablewriter.FgHiRedColor},
+		},
+	)
+	return t
+}
+
+func WaitingStyle(t *tablewriter.Table, data []string) *tablewriter.Table {
+	t.Rich(
+		data,
+		[]tablewriter.Colors{
+			{tablewriter.Bold, tablewriter.FgHiCyanColor},
+			{tablewriter.Bold, tablewriter.FgHiYellowColor},
+		},
+	)
 	return t
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -35,7 +35,13 @@ func TestReadConfigFile(t *testing.T) {
 		wantExt := "yaml"
 
 		if gotFilename != wantFilename || gotExt != wantExt {
-			t.Errorf("got: %s, want: %s, got: %s, want: %s", gotFilename, wantFilename, gotExt, wantExt)
+			t.Errorf(
+				"got: %s, want: %s, got: %s, want: %s",
+				gotFilename,
+				wantFilename,
+				gotExt,
+				wantExt,
+			)
 		}
 	})
 }


### PR DESCRIPTION
Ahoy! First of all, this has been a really useful tool.

After some time neglecting a stable of repositories with automated dependency updates, I had a depressing number of PRs to merge, with mix of failing and passing status checks. I needed a way to bulk merge only those that pass checks, and set about trying to display the commit status in the summary table. This PR is the result of that attempt, which got slightly out of hand. It includes the following changes:

- Display the check status of the last commit to a PR in the summary table (fixes #12). This turns out to be impossible to get from the v3 API ([the commit status endpoint is just broken](https://github.com/orgs/community/discussions/70099)), so I switched to the GraphQL-based v4 API.
- Interpret repo names without a slash as owners, and search for PRs against repos with that owner (simpler in the GraphQL API, and useful for me)
- Consolidate PR manipulation for multi/single-repo case
- Omit commit message when merging (effectively fixes #105 by letting GitHub generate the commit body, including co-author fields)
- Optionally filter PRs by label (fixes #79). This added more complexity than I would have liked because of the way that the query is encoded in struct tags, and there may be a cleaner way to do this.
- Attempt to approve PRs that need reviews before merging them (addresses #96, but without the UX). Note that this only works for repos with classic branch protection rules; the new-style repository rulesets don't seem to appear in the API.

I realize that this is kind of a monster, and am happy to break it down into smaller changes if that's helpful. Comments welcome!